### PR TITLE
fix: made StartsAt and EffectiveDate properties nullable

### DIFF
--- a/AscentCsvBuilder/AscentCsvBuilder.csproj
+++ b/AscentCsvBuilder/AscentCsvBuilder.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/AscentCsvBuilder/Models/AscentResponseModel.cs
+++ b/AscentCsvBuilder/Models/AscentResponseModel.cs
@@ -92,7 +92,7 @@ public class Attributes
     public long Position { get; set; }
 
     [JsonPropertyName("startsAt")]
-    public DateTimeOffset StartsAt { get; set; }
+    public DateTimeOffset? StartsAt { get; set; }
 
     [JsonPropertyName("endsAt")]
     public DateTimeOffset? EndsAt { get; set; }

--- a/AscentCsvBuilder/Models/OutputDataModel.cs
+++ b/AscentCsvBuilder/Models/OutputDataModel.cs
@@ -79,7 +79,7 @@ public class Rule
     public long Position { get; set; }
 
     [Name("Effective Date")]
-    public DateTimeOffset EffectiveDate { get; set; }
+    public DateTimeOffset? EffectiveDate { get; set; }
 
     [Name("Expiration Date")]
     public DateTimeOffset? ExpirationDate { get; set; }
@@ -166,7 +166,7 @@ public class Obligation
     public string Citation { get; set; }
 
     [Name("Effective Date")]
-    public DateTimeOffset EffectiveDate { get; set; }
+    public DateTimeOffset? EffectiveDate { get; set; }
 
     [Name("Expiration Date")]
     public DateTimeOffset? ExpirationDate { get; set; }


### PR DESCRIPTION
fix: made StartsAt property on the Attributes class in AscentResponseModel class nullable. Also made EffectiveDate property on the Rule class and Obligation class in OutputDataModel.cs nullable as well.

This would prevent an issue with deserialization when an ascent data model is processed that has null passed for the startsAt property.

Closes #1 

With this change the console application builds successfully and will run. Did encounter a subsequent null reference exception which has been addressed in #4 