### PR TITLE
Fix: null reference exception when hiearchy is empty array

### DIFF
--- a/AscentCsvBuilder/AscentCsvBuilder.csproj
+++ b/AscentCsvBuilder/AscentCsvBuilder.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/AscentCsvBuilder/Models/AscentResponseModel.cs
+++ b/AscentCsvBuilder/Models/AscentResponseModel.cs
@@ -92,7 +92,7 @@ public class Attributes
     public long Position { get; set; }
 
     [JsonPropertyName("startsAt")]
-    public DateTimeOffset StartsAt { get; set; }
+    public DateTimeOffset? StartsAt { get; set; }
 
     [JsonPropertyName("endsAt")]
     public DateTimeOffset? EndsAt { get; set; }

--- a/AscentCsvBuilder/Models/OutputDataModel.cs
+++ b/AscentCsvBuilder/Models/OutputDataModel.cs
@@ -79,7 +79,7 @@ public class Rule
     public long Position { get; set; }
 
     [Name("Effective Date")]
-    public DateTimeOffset EffectiveDate { get; set; }
+    public DateTimeOffset? EffectiveDate { get; set; }
 
     [Name("Expiration Date")]
     public DateTimeOffset? ExpirationDate { get; set; }
@@ -166,7 +166,7 @@ public class Obligation
     public string Citation { get; set; }
 
     [Name("Effective Date")]
-    public DateTimeOffset EffectiveDate { get; set; }
+    public DateTimeOffset? EffectiveDate { get; set; }
 
     [Name("Expiration Date")]
     public DateTimeOffset? ExpirationDate { get; set; }

--- a/AscentCsvBuilder/Models/OutputDataModel.cs
+++ b/AscentCsvBuilder/Models/OutputDataModel.cs
@@ -53,8 +53,8 @@ public class Rule
         PublishedDate = datum.Attributes.PublishedDate;
         CreatedAt = datum.Attributes.CreatedAt;
         ModifiedAt = datum.Attributes.ModifiedAt;
-        RegulatorId = datum.Attributes.Hierarchy.FirstOrDefault(f => f.Type == "regulator").Id;
-        RegulatorName = datum.Attributes.Hierarchy.FirstOrDefault(f => f.Type == "regulator").Name;
+        RegulatorId = datum.Attributes.Hierarchy.FirstOrDefault(f => f.Type == "regulator")?.Id;
+        RegulatorName = datum.Attributes.Hierarchy.FirstOrDefault(f => f.Type == "regulator")?.Name;
         Link = datum.Attributes.Links.App.ToString();
         Section = datum.Attributes.Hierarchy[1].Name;
         Subsection = datum.Attributes.Hierarchy[0].Name;
@@ -121,8 +121,8 @@ public class Obligation
         Preview = datum.Attributes.Preview;
         StatusChangedAt = datum.Attributes.StatusChangedAt;
         Link = datum.Attributes.Links.Self.ToString();
-        RegulatoryRule = datum.Attributes.Hierarchy.FirstOrDefault(f => f.Type == "rule").Id;
-        Regulator = datum.Attributes.Hierarchy.FirstOrDefault(f => f.Type == "regulator").Id;
+        RegulatoryRule = datum.Attributes.Hierarchy.FirstOrDefault(f => f.Type == "rule")?.Id;
+        Regulator = datum.Attributes.Hierarchy.FirstOrDefault(f => f.Type == "regulator")?.Id;
         Citation = datum.Attributes.Citation;
         EffectiveDate = datum.Attributes.StartsAt;
         ExpirationDate = datum.Attributes.EndsAt;


### PR DESCRIPTION
Added null conditional operators when attempting to get the `Id` and `Name` values from the `Hierarchy` property to set the `RegulatorId` and `RegulatorName` properties in the `Rule` class's constructor.

Added null conditional operators when attempting to get `Id` values from the `Hierarchy` property to set the `RegulatoryRule` and `Regulator` properties in the `Obligation` class's constructor.

Closes #2 

With these changes the application does build successfully and I was able to run the program to completion without issue.